### PR TITLE
Rest API updates

### DIFF
--- a/docs/reference/restapi.md
+++ b/docs/reference/restapi.md
@@ -15,6 +15,13 @@ title: REST API
 
 ## Changelog
 
+### 2023-12-06
+
+- Added `statistics` to `/models/:id`. `statistics` contains aggregated automation percentages for the fields in the
+model's `fieldConfig` from the last number of days, defaulting to last 7 days.
+- Added optional `statisticsLastNDays` to `GET /models/:id`. Specify a number of days between 1 and 30 to get
+`statistics` from.
+
 ### 2023-12-05
 
 - Added optional `outputFormat` to `postprocessConfig` in `POST /models`, `PATCH /models/:id` and `POST /predictions`.

--- a/static/oas.json
+++ b/static/oas.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Lucidtech API",
-    "version": "2023-12-01T13:15:44Z"
+    "version": "2023-12-06T14:19:14Z"
   },
   "servers": [
     {
@@ -5803,6 +5803,13 @@
       },
       "get": {
         "parameters": [
+          {
+            "in": "query",
+            "name": "statisticsLastNDays",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "in": "path",
             "name": "modelId",
@@ -20277,6 +20284,10 @@
                   "type": "string",
                   "nullable": true
                 },
+                "statistics": {
+                  "type": "object",
+                  "nullable": true
+                },
                 "status": {
                   "type": "string",
                   "enum": [
@@ -23606,6 +23617,10 @@
           "createdTime": {
             "pattern": "^[0-9]{4}-?[0-9]{2}-?[0-9]{2}( |T)?[0-9]{2}:?[0-9]{2}:?[0-9]{2}(.[0-9]{1,6})?(Z|[+][0-9]{2}(:|)[0-9]{2})$",
             "type": "string",
+            "nullable": true
+          },
+          "statistics": {
+            "type": "object",
             "nullable": true
           },
           "status": {

--- a/static/oas.yaml
+++ b/static/oas.yaml
@@ -1338,6 +1338,9 @@ components:
               - 270
               type: integer
           type: object
+        statistics:
+          nullable: true
+          type: object
         status:
           enum:
           - active
@@ -1567,6 +1570,9 @@ components:
                     - 180
                     - 270
                     type: integer
+                type: object
+              statistics:
+                nullable: true
                 type: object
               status:
                 enum:
@@ -5527,7 +5533,7 @@ components:
       type: oauth2
 info:
   title: Lucidtech API
-  version: '2023-12-01T13:15:44Z'
+  version: '2023-12-06T14:19:14Z'
 openapi: 3.0.1
 paths:
   /appClients:
@@ -8900,6 +8906,10 @@ paths:
         - api.lucidtech.ai/models:read
     get:
       parameters:
+      - in: query
+        name: statisticsLastNDays
+        schema:
+          type: string
       - in: path
         name: modelId
         required: true


### PR DESCRIPTION
### 2023-12-06

- Added `statistics` to `/models/:id`. `statistics` contains aggregated automation percentages for the fields in the
model's `fieldConfig` from the last number of days, defaulting to last 7 days.
- Added optional `statisticsLastNDays` to `GET /models/:id`. Specify a number of days between 1 and 30 to get